### PR TITLE
Requirement 1 - Task Due Date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :test, :development do
   gem 'rspec-rails'
   gem 'guard-rails'
   gem 'guard-rspec'
+  gem 'capybara'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,17 @@ GEM
     activesupport (3.2.17)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (3.0.3)
     builder (3.0.4)
+    capybara (2.18.0)
+      addressable
+      mini_mime (>= 0.1.3)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (>= 2.0, < 4.0)
     celluloid (0.15.2)
       timers (~> 1.1.0)
     coderay (1.1.0)
@@ -65,12 +74,17 @@ GEM
       treetop (~> 1.4.8)
     method_source (0.8.2)
     mime-types (1.25.1)
+    mini_mime (1.0.2)
+    mini_portile2 (2.1.0)
     multi_json (1.9.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
     polyglot (0.3.4)
     pry (0.9.12.4)
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
+    public_suffix (2.0.5)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -129,14 +143,20 @@ GEM
       polyglot
       polyglot (>= 0.3.1)
     tzinfo (0.3.39)
+    xpath (2.1.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   guard-rails
   guard-rspec
   jquery-rails
   rails (= 3.2.17)
   rspec-rails
   sqlite3
+
+BUNDLED WITH
+   1.17.3

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ActiveRecord::Base
   belongs_to :list
-  attr_accessible :complete, :name
+  attr_accessible :complete, :name, :due_date
 
   validates :name, presence: true
 end

--- a/app/views/lists/tasks/_form.html.erb
+++ b/app/views/lists/tasks/_form.html.erb
@@ -18,6 +18,10 @@
     <%= f.label :complete, "Complete?" %><br />
     <%= f.check_box :complete %>
   </div>
+  <div class="field">
+    <%= f.label :due_date, "Due Date" %><br />
+    <%= f.text_field :due_date %> Format: "yyyy-mm-dd"
+  </div>
   <div class="actions">
     <%= f.submit %>
   </div>

--- a/app/views/lists/tasks/index.html.erb
+++ b/app/views/lists/tasks/index.html.erb
@@ -4,6 +4,7 @@
   <tr>
     <th>Name</th>
     <th>Complete?</th>
+    <th>Due Date</th>
     <th></th>
     <th></th>
     <th></th>
@@ -12,6 +13,11 @@
     <tr>
       <td><%= task.name %></td>
       <td><%= task.complete %></td>
+      <% if task.due_date %>
+        <td><%= task.due_date %></td>
+      <% else %>
+        <td> N/A </td>
+      <% end %>
       <td><%= link_to 'Show', list_task_path(@list, task) %></td>
       <td><%= link_to 'Edit', edit_list_task_path(@list, task) %></td>
       <td><%= link_to 'Destroy', list_task_path(@list, task), method: :delete, confirm: 'Are you sure?' %></td>

--- a/db/migrate/20140318155532_create_tasks.rb
+++ b/db/migrate/20140318155532_create_tasks.rb
@@ -3,6 +3,8 @@ class CreateTasks < ActiveRecord::Migration
     create_table :tasks do |t|
       t.string :name
       t.boolean :complete
+      t.time :due_date
+
       t.belongs_to :list
 
       t.timestamps

--- a/db/migrate/20140318155532_create_tasks.rb
+++ b/db/migrate/20140318155532_create_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasks < ActiveRecord::Migration
     create_table :tasks do |t|
       t.string :name
       t.boolean :complete
-      t.time :due_date
+      t.string :due_date
 
       t.belongs_to :list
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(:version => 20140318155532) do
   create_table "tasks", :force => true do |t|
     t.string   "name"
     t.boolean  "complete"
+    t.time     "due_date"
     t.integer  "list_id"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(:version => 20140318155532) do
   create_table "tasks", :force => true do |t|
     t.string   "name"
     t.boolean  "complete"
-    t.time     "due_date"
+    t.string   "due_date"
     t.integer  "list_id"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false

--- a/spec/features/user_can_create_list_spec.rb
+++ b/spec/features/user_can_create_list_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe 'A user who visits the app' do
+  # -------------------------------------
+  it 'can create a list' do
+    visit '/'
+
+    click_on 'New List'
+    expect(current_path).to eq(new_list_path)
+  end
+end
+

--- a/spec/features/user_can_create_list_spec.rb
+++ b/spec/features/user_can_create_list_spec.rb
@@ -7,6 +7,12 @@ describe 'A user who visits the app' do
 
     click_on 'New List'
     expect(current_path).to eq(new_list_path)
+
+    fill_in :list_title, with: "Big Financial Decisions"
+    click_on "Create List"
+    expect(current_path).to eq(list_path(List.last))
+    expect(page).to have_content('Big Financial Decisions')
   end
+  # -------------------------------------
 end
 

--- a/spec/features/user_can_create_task_spec.rb
+++ b/spec/features/user_can_create_task_spec.rb
@@ -1,1 +1,31 @@
 require 'spec_helper'
+
+describe 'A user who visits the app' do
+  # -------------------------------------
+  it 'can create a task' do
+    list_1 = List.create(title: "Dogs I want")
+
+    
+    visit list_path(list_1.id)
+    expect(page).to have_content('Dogs I want')
+
+    click_on "Tasks"
+    expect(current_path).to eq(list_tasks_path(list_1.id))
+
+    click_on "New Task"
+    expect(current_path).to eq(new_list_task_path(list_1.id))
+
+    fill_in :task_name, with: "Poodle"
+    fill_in :task_due_date, with: "2022-12-25"
+
+    click_on "Create Task"
+    expect(current_path).to eq("/lists/#{list_1.id}/tasks/#{Task.last.id}")
+
+    click_on "Back"
+    expect(current_path).to eq(list_tasks_path(list_1.id))
+    expect(page).to have_content("Poodle")
+    expect(page).to have_content("2022-12-25")
+  end
+  # -------------------------------------
+end
+

--- a/spec/features/user_can_create_task_spec.rb
+++ b/spec/features/user_can_create_task_spec.rb
@@ -1,0 +1,1 @@
+require 'spec_helper'

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -7,4 +7,16 @@ describe Task do
       expect(subject.valid?).to be_false
     end
   end
+
+  context 'attributes' do
+    future_date = Time.parse("2030-04-01")
+    list_1 = List.create(title: "Big Financial Decisions")
+    task_1 = Task.create(name: "Purchase a Kia Telluride", complete: false, due_date: future_date)
+    task_1.list_id = 1
+    
+    it 'should have a due_date' do
+      expect(task_1.due_date).to eq(future_date)
+    end
+
+  end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -18,5 +18,17 @@ describe Task do
       expect(task_1.due_date).to eq(future_date)
     end
 
+    it 'should have a name' do
+      expect(task_1.name).to eq('Purchase a Kia Telluride')
+    end
+
+    it 'should have a completion status' do
+      expect(task_1.complete).to eq(false)
+    end
+
+    it 'should belong to a list' do
+      expect(task_1.list_id).to eq(1)
+    end
+
   end
 end


### PR DESCRIPTION
This feature is about adding the ability to set a due date on a Task.

I was going to add a jquery plugin for a nice calendar, but rails forms were easier to integrate a simple text field. If a pretty UX/UI was requested I would migrate to the jquery plugin, which can be found here: https://jqueryui.com/datepicker/

^ possible future iteration

-----------
<img width="424" alt="Screen Shot 2019-08-31 at 3 07 50 PM" src="https://user-images.githubusercontent.com/40616788/64069168-85014f80-cc01-11e9-8c00-0d7aba06d522.png">


----
Users can now set a due date when they create a task, and the date is displayed on the index page of their tasks at the route: "/list/list_id/tasks".
